### PR TITLE
Fix: no battery data on Apple silicon (M4) + remove unsound transmutes

### DIFF
--- a/crates/tpower/src/de.rs
+++ b/crates/tpower/src/de.rs
@@ -72,25 +72,30 @@ with_repr! {
     #[repr, serde(rename_all(deserialize = "PascalCase", serialize = "camelCase"))]
     #[derive(Debug, Clone, Default, Deserialize, Serialize)]
     pub struct IORegistry {
+        #[serde(default)]
         pub adapter_details: AdapterDetails,
         pub power_telemetry_data: Option<PowerTelemetryData>,
-        pub absolute_capacity: i32,
-        pub amperage: i32,
-        pub voltage: i32,
+        // All scalar fields are Option<T>: IOKit's AppleSmartBattery dictionary
+        // exposes different key sets across Macs (e.g. Apple silicon / M4 omits
+        // `AbsoluteCapacity`). serde maps a missing Option field to None, so the
+        // whole parse no longer fails atomically when one key is absent.
+        pub absolute_capacity: Option<i32>,
+        pub amperage: Option<i32>,
+        pub voltage: Option<i32>,
         pub apple_raw_battery_voltage: Option<i32>,
-        pub apple_raw_current_capacity: i32,
-        pub apple_raw_max_capacity: i32,
-        pub current_capacity: i32,
-        pub cycle_count: i32,
-        pub design_capacity: i32,
-        pub fully_charged: bool,
-        pub instant_amperage: i32,
-        pub is_charging: bool,
-        pub max_capacity: i32,
-        pub temperature: i32,
-        pub time_remaining: i32,
+        pub apple_raw_current_capacity: Option<i32>,
+        pub apple_raw_max_capacity: Option<i32>,
+        pub current_capacity: Option<i32>,
+        pub cycle_count: Option<i32>,
+        pub design_capacity: Option<i32>,
+        pub fully_charged: Option<bool>,
+        pub instant_amperage: Option<i32>,
+        pub is_charging: Option<bool>,
+        pub max_capacity: Option<i32>,
+        pub temperature: Option<i32>,
+        pub time_remaining: Option<i32>,
         // TODO: check
-        pub update_time: i64,
+        pub update_time: Option<i64>,
     }
 }
 
@@ -104,5 +109,64 @@ impl Deref for IORegistry {
 impl IORegistry {
     pub fn ptd(&self) -> Option<&PowerTelemetryData> {
         self.power_telemetry_data.as_ref()
+    }
+}
+
+// `provider::get_mac_ioreg` and `provider::remote` parse into the `repr::*`
+// (PascalCase-deserialize) structs, then convert to their public (camelCase,
+// specta-deriving) twins. These `From` impls replace an earlier `mem::transmute`
+// between the twins: transmuting `repr(Rust)` structs is not a layout guarantee
+// Rust makes, and the previous code even transmuted a whole `Result`, turning a
+// parse error into a bad `anyhow::Error` pointer that segfaulted. A field-by-field
+// move is zero-cost and fails to compile if the two ever drift apart.
+impl From<repr::AdapterDetails> for AdapterDetails {
+    fn from(r: repr::AdapterDetails) -> Self {
+        Self {
+            adapter_voltage: r.adapter_voltage,
+            is_wireless: r.is_wireless,
+            watts: r.watts,
+            name: r.name,
+            current: r.current,
+            description: r.description,
+        }
+    }
+}
+
+impl From<repr::PowerTelemetryData> for PowerTelemetryData {
+    fn from(r: repr::PowerTelemetryData) -> Self {
+        Self {
+            adapter_efficiency_loss: r.adapter_efficiency_loss,
+            battery_power: r.battery_power,
+            system_current_in: r.system_current_in,
+            system_energy_consumed: r.system_energy_consumed,
+            system_load: r.system_load,
+            system_power_in: r.system_power_in,
+            system_voltage_in: r.system_voltage_in,
+        }
+    }
+}
+
+impl From<repr::IORegistry> for IORegistry {
+    fn from(r: repr::IORegistry) -> Self {
+        Self {
+            adapter_details: r.adapter_details.into(),
+            power_telemetry_data: r.power_telemetry_data.map(Into::into),
+            absolute_capacity: r.absolute_capacity,
+            amperage: r.amperage,
+            voltage: r.voltage,
+            apple_raw_battery_voltage: r.apple_raw_battery_voltage,
+            apple_raw_current_capacity: r.apple_raw_current_capacity,
+            apple_raw_max_capacity: r.apple_raw_max_capacity,
+            current_capacity: r.current_capacity,
+            cycle_count: r.cycle_count,
+            design_capacity: r.design_capacity,
+            fully_charged: r.fully_charged,
+            instant_amperage: r.instant_amperage,
+            is_charging: r.is_charging,
+            max_capacity: r.max_capacity,
+            temperature: r.temperature,
+            time_remaining: r.time_remaining,
+            update_time: r.update_time,
+        }
     }
 }

--- a/crates/tpower/src/provider/mod.rs
+++ b/crates/tpower/src/provider/mod.rs
@@ -119,6 +119,16 @@ impl Deref for NormalizedResource {
     }
 }
 
+/// Battery charge as a percentage of raw max capacity. Returns 0.0 when either
+/// raw value is missing or max is non-positive, avoiding a 0/0 -> NaN or x/0 ->
+/// inf in the emitted telemetry.
+fn absolute_battery_level(io: &IORegistry) -> f32 {
+    match (io.apple_raw_current_capacity, io.apple_raw_max_capacity) {
+        (Some(current), Some(max)) if max > 0 => current as f32 / max as f32 * 100.,
+        _ => 0.,
+    }
+}
+
 impl From<&IORegistry> for NormalizedResource {
     fn from(io: &IORegistry) -> Self {
         let (system_in, system_load, battery_power, adapter_power, efficiency_loss) =
@@ -136,18 +146,18 @@ impl From<&IORegistry> for NormalizedResource {
 
         Self {
             is_local: false,
-            is_charging: io.is_charging,
-            time_remain: Duration::from_secs(io.time_remaining as u64 * 60),
-            last_update: io.update_time,
+            is_charging: io.is_charging.unwrap_or_default(),
+            time_remain: Duration::from_secs(io.time_remaining.unwrap_or_default() as u64 * 60),
+            last_update: io.update_time.unwrap_or_default(),
             adapter_name: io
                 .adapter_details
                 .name
                 .clone()
                 .or_else(|| io.adapter_details.description.clone()),
-            cycle_count: io.cycle_count,
-            max_capacity: io.apple_raw_max_capacity,
-            design_capacity: io.design_capacity,
-            current_capacity: io.apple_raw_current_capacity,
+            cycle_count: io.cycle_count.unwrap_or_default(),
+            max_capacity: io.apple_raw_max_capacity.unwrap_or_default(),
+            design_capacity: io.design_capacity.unwrap_or_default(),
+            current_capacity: io.apple_raw_current_capacity.unwrap_or_default(),
             data: NormalizedData {
                 system_in,
                 system_load,
@@ -156,11 +166,9 @@ impl From<&IORegistry> for NormalizedResource {
                 efficiency_loss,
                 brightness_power: 0.,
                 heatpipe_power: 0.,
-                battery_level: io.current_capacity,
-                absolute_battery_level: io.apple_raw_current_capacity as f32
-                    / io.apple_raw_max_capacity as f32
-                    * 100.,
-                temperature: io.temperature as f32 / 100.,
+                battery_level: io.current_capacity.unwrap_or_default(),
+                absolute_battery_level: absolute_battery_level(io),
+                temperature: io.temperature.unwrap_or_default() as f32 / 100.,
 
                 adapter_watts: io.adapter_details.watts.unwrap_or_default() as f32,
                 adapter_voltage: io.adapter_details.adapter_voltage.unwrap_or_default() as f32
@@ -175,7 +183,7 @@ impl From<(&IORegistry, &SMCPowerData)> for NormalizedResource {
     fn from((io, smc): (&IORegistry, &SMCPowerData)) -> Self {
         Self {
             is_local: true,
-            last_update: io.update_time,
+            last_update: io.update_time.unwrap_or_default(),
             is_charging: smc.is_charging(),
             time_remain: Duration::from_secs_f32(
                 60.0 * if smc.is_charging() {
@@ -189,10 +197,10 @@ impl From<(&IORegistry, &SMCPowerData)> for NormalizedResource {
                 .name
                 .clone()
                 .or_else(|| io.adapter_details.description.clone()),
-            cycle_count: io.cycle_count,
-            max_capacity: io.apple_raw_max_capacity,
-            design_capacity: io.design_capacity,
-            current_capacity: io.apple_raw_current_capacity,
+            cycle_count: io.cycle_count.unwrap_or_default(),
+            max_capacity: io.apple_raw_max_capacity.unwrap_or_default(),
+            design_capacity: io.design_capacity.unwrap_or_default(),
+            current_capacity: io.apple_raw_current_capacity.unwrap_or_default(),
             data: NormalizedData {
                 system_in: smc.delivery_rate,
                 system_load: smc.system_total,
@@ -202,10 +210,8 @@ impl From<(&IORegistry, &SMCPowerData)> for NormalizedResource {
                     .map_or(0.0, |d| d.adapter_efficiency_loss as f32 / 1000.),
                 brightness_power: smc.brightness,
                 heatpipe_power: smc.heatpipe,
-                battery_level: io.current_capacity,
-                absolute_battery_level: io.apple_raw_current_capacity as f32
-                    / io.apple_raw_max_capacity as f32
-                    * 100.,
+                battery_level: io.current_capacity.unwrap_or_default(),
+                absolute_battery_level: absolute_battery_level(io),
                 temperature: smc.temperature,
                 adapter_power: smc.delivery_rate
                     + io.ptd()
@@ -242,7 +248,7 @@ pub fn get_mac_ioreg_dict() -> anyhow::Result<CFDictionary> {
 
 pub fn get_mac_ioreg() -> anyhow::Result<IORegistry> {
     let dic = get_mac_ioreg_dict()?;
-    unsafe { mem::transmute(dict_into::<repr::IORegistry>(dic)) }
+    Ok(dict_into::<repr::IORegistry>(dic)?.into())
 }
 
 #[derive(Debug)]

--- a/crates/tpower/src/provider/remote.rs
+++ b/crates/tpower/src/provider/remote.rs
@@ -1,5 +1,3 @@
-use std::mem;
-
 use core_foundation::{base::TCFType, dictionary::CFDictionary};
 use thiserror::Error;
 
@@ -38,6 +36,5 @@ pub fn get_device_ioreg(conn: &ServiceConnection) -> Result<IORegistry, DeviceDa
 
     let data = dict_into::<repr::IORegistryDiagnostic>(response)?;
 
-    // SAFETY: IORegistry and repr::IORegistry are disigned to be the same
-    unsafe { mem::transmute(data.diagnostics.ioregistry) }
+    Ok(data.diagnostics.ioregistry.into())
 }

--- a/src-tauri/src/local.rs
+++ b/src-tauri/src/local.rs
@@ -81,22 +81,36 @@ pub fn start_sender<R: Runtime>(
             select! {
                 _ = timer.tick() => {
                     let smc = smc_conn.read_sensor();
-                    PowerUpdatedEvent::new_with(&smc, &status_bar_item, show_charging)
+                    if let Err(e) = PowerUpdatedEvent::new_with(&smc, &status_bar_item, show_charging)
                         .emit(&app)
-                        .unwrap();
-                    PowerTickEvent {
-                        data: (&get_mac_ioreg().unwrap(), &smc).into(),
-                    }.emit(&app).unwrap();
+                    {
+                        log::warn!("failed to emit PowerUpdatedEvent: {e}");
+                    }
+                    match get_mac_ioreg() {
+                        Ok(ioreg) => {
+                            if let Err(e) = (PowerTickEvent { data: (&ioreg, &smc).into() }).emit(&app) {
+                                log::warn!("failed to emit PowerTickEvent: {e}");
+                            }
+                        }
+                        Err(e) => log::warn!("failed to read mac ioreg: {e:?}"),
+                    }
                 }
                 Some(msg) = rx.recv() => match msg {
                     SenderMessage::ImmediateSend => {
                         let smc = smc_conn.read_sensor();
-                        PowerUpdatedEvent::new_with(&smc, &status_bar_item, show_charging)
+                        if let Err(e) = PowerUpdatedEvent::new_with(&smc, &status_bar_item, show_charging)
                             .emit(&app)
-                            .unwrap();
-                        PowerTickEvent {
-                            data:  (&get_mac_ioreg().unwrap(), &smc).into()
-                        }.emit(&app).unwrap();
+                        {
+                            log::warn!("failed to emit PowerUpdatedEvent: {e}");
+                        }
+                        match get_mac_ioreg() {
+                            Ok(ioreg) => {
+                                if let Err(e) = (PowerTickEvent { data: (&ioreg, &smc).into() }).emit(&app) {
+                                    log::warn!("failed to emit PowerTickEvent: {e}");
+                                }
+                            }
+                            Err(e) => log::warn!("failed to read mac ioreg: {e:?}"),
+                        }
                     },
                     SenderMessage::ChangeInterval(interval) => {
                         timer = time::interval(if interval < Duration::from_millis(500) {
@@ -108,15 +122,19 @@ pub fn start_sender<R: Runtime>(
                     },
                     SenderMessage::ChangeStatusBarItem(item) => {
                         status_bar_item = item;
-                        PowerUpdatedEvent::new_with(&smc_conn.read_sensor(), &status_bar_item, show_charging)
+                        if let Err(e) = PowerUpdatedEvent::new_with(&smc_conn.read_sensor(), &status_bar_item, show_charging)
                             .emit(&app)
-                            .unwrap();
+                        {
+                            log::warn!("failed to emit PowerUpdatedEvent: {e}");
+                        }
                     },
                     SenderMessage::StatusBarShowCharging(show) => {
                         show_charging = show;
-                        PowerUpdatedEvent::new_with(&smc_conn.read_sensor(), &status_bar_item, show_charging)
+                        if let Err(e) = PowerUpdatedEvent::new_with(&smc_conn.read_sensor(), &status_bar_item, show_charging)
                             .emit(&app)
-                            .unwrap();
+                        {
+                            log::warn!("failed to emit PowerUpdatedEvent: {e}");
+                        }
                     }
                 }
             }
@@ -134,7 +152,9 @@ pub fn setup_sender_with_events<R: Runtime>(app: &impl Manager<R>) {
     WindowLoadedEvent::listen(app, move |_| {
         let tx = tx.clone();
         async_runtime::spawn(async move {
-            tx.send(SenderMessage::ImmediateSend).await.unwrap();
+            if let Err(e) = tx.send(SenderMessage::ImmediateSend).await {
+                log::warn!("failed to send ImmediateSend: {e}");
+            }
         });
     });
 
@@ -156,7 +176,9 @@ pub fn setup_sender_with_events<R: Runtime>(app: &impl Manager<R>) {
         } {
             let tx = tx.clone();
             async_runtime::spawn(async move {
-                tx.send(msg).await.unwrap();
+                if let Err(e) = tx.send(msg).await {
+                    log::warn!("failed to send SenderMessage: {e}");
+                }
             });
         }
     });


### PR DESCRIPTION
## Problem

On Apple silicon (tested on M4 / macOS 26) the app launches but shows **no battery data**. The log repeats:

```
failed to parse plist: Serde("missing field `AbsoluteCapacity`")
```

The `AppleSmartBattery` IORegistry dictionary on Apple silicon omits `AbsoluteCapacity` (and some other keys). Because `IORegistry` declared those as required `i32`, serde rejects the **entire** plist atomically — so every other valid battery value is discarded too.

While tracing it I also hit a hard **segfault (SIGSEGV at 0x8)** on launch: `get_mac_ioreg` did `mem::transmute(dict_into::<repr::IORegistry>(dic))`, transmuting the whole `Result<repr::IORegistry, DictParseError>` into `anyhow::Result<IORegistry>`. On the parse-failure path that reinterprets a `DictParseError` as an `anyhow::Error` pointer → crash. `remote.rs` had the same `Result`/struct transmute pattern.

## Fix

- **Tolerant parsing:** make `IORegistry` scalar fields `Option<T>` (serde maps a missing `Option` field to `None`) and `#[serde(default)]` the nested `adapter_details`. Missing keys now degrade to `None`/default instead of failing the whole parse. Readers in `NormalizedResource::from` updated with `unwrap_or_default()`.
- **Remove the transmutes:** replace the `repr::* -> public` `mem::transmute` in `get_mac_ioreg` and `remote.rs` with `From` impls. Transmuting `repr(Rust)` structs isn't a layout guarantee, and the field-by-field move is zero-cost + fails to compile if the twin structs ever drift.
- **Don't panic the sender loop:** the power-update task `unwrap()`-ed on every `emit()` / `get_mac_ioreg()`; a single failure killed the task (and on Tauri, the app). Now it logs and continues.
- **Guard the percentage division** (`apple_raw_current_capacity / apple_raw_max_capacity`) against divide-by-zero / NaN.

## Testing

- `cargo check` + `cargo clippy -p tpower` clean.
- Release build runs on M4 (macOS 26): app launches, no `missing field` errors, battery data + menubar power both populate, no crash.

No public API/TS change — `IORegistry` is internal; the frontend consumes `NormalizedResource`, which is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)